### PR TITLE
fix: Buttons do not need to be displayed when WeChat share is off.

### DIFF
--- a/Core/StlShare.cs
+++ b/Core/StlShare.cs
@@ -46,7 +46,7 @@ namespace SSCMS.Share.Core
             var origin = string.Empty;
             var description = string.Empty;
             var image = string.Empty;
-            var sites = "wechat, weibo, qq, qzone, douban";
+            var sites = "weibo, qq, qzone, douban";
             var disabled = string.Empty;
             var wechatQrcodeTitle = string.Empty;
             var wechatQrcodeHelper = string.Empty;
@@ -104,6 +104,12 @@ namespace SSCMS.Share.Core
 
             var settings = await _shareManager.GetSettingsAsync(context.SiteId);
             var site = await _siteRepository.GetAsync(context.SiteId);
+
+            if (settings.IsWxShare)
+            {
+                sites += ",wechat";
+            }
+
             var cssUrl = _pathManager.GetApiHostUrl(site, "/assets/share/css/share.min.css");
             var jsUrl = _pathManager.GetApiHostUrl(site, "/assets/share/js/social-share.min.js");
 

--- a/Pages/ss-admin/share/Index.cshtml
+++ b/Pages/ss-admin/share/Index.cshtml
@@ -1,101 +1,104 @@
 ﻿@page
-@{ Layout = "_Layout"; }
+@{
+    Layout = "_Layout"; 
+}
 
 <el-tabs type="border-card">
-  <el-tab-pane label="页面分享设置">
+    <el-tab-pane label="页面分享设置">
 
-    <el-alert type="info">
-      页面分享标签：<strong>&lt;stl:share&gt;&lt;/stl:share&gt;</strong>
-    </el-alert>
+        <el-alert type="info">
+            页面分享标签：<strong>&lt;stl:share&gt;&lt;/stl:share&gt;</strong>
+        </el-alert>
 
-    <div style="height: 10px"></div>
+        <div style="height: 10px"></div>
 
-    <el-form size="small" ref="settingsForm" label-width="260px" status-icon :model="settingsForm">
-      <el-form-item label="默认页面标题" prop="defaultTitle" :rules="{ required: true, message: '请输入默认页面标题' }">
-        <el-input v-model="settingsForm.defaultTitle" placeholder="请输入默认页面标题"></el-input>
-        <div class="tips">当分享插件未获取到页面标题时将使用默认页面标题</div>
-      </el-form-item>
-      <el-form-item label="默认封面图片" prop="defaultImageUrl" :rules="{ required: true, message: '请输入图片地址或点击上方按钮上传' }">
-        <el-button-group>
-          <el-button size="mini" type="info" icon="el-icon-upload2" plain v-on:click="btnLayerClick({title: '上传图片', name: 'formLayerImageUpload', attributeName: 'defaultImageUrl', no: 0})">
-            上传
-          </el-button>
-          <el-button size="mini" type="info" icon="el-icon-folder-opened" plain v-on:click="btnLayerClick({title: '选择图片素材', name: 'materialLayerImageSelect', attributeName: 'defaultImageUrl', no: 0, full: true})">
-            选择
-          </el-button>
-          <el-button size="mini" type="info" icon="el-icon-view" plain :disabled="settingsForm.defaultImageUrl ? false : true" v-on:click="btnPreviewClick('defaultImageUrl', 0)">
-            预览
-          </el-button>
-        </el-button-group>
-        <el-input
-          v-model="settingsForm.defaultImageUrl"
-          placeholder="请输入图片地址或点击上方按钮上传">
-        </el-input>
-        <div class="tips">当分享插件未获取到封面图片时将使用默认封面图片</div>
-      </el-form-item>
-      <el-form-item label="默认页面介绍" prop="defaultDescription" :rules="{ required: true, message: '请输入默认页面介绍' }">
-        <el-input v-model="settingsForm.defaultDescription" type="textarea" :rows="5" placeholder="请输入默认页面介绍"></el-input>
-        <div class="tips">当分享插件未获取到页面介绍时将使用默认页面介绍</div>
-      </el-form-item>
-    </el-form>
+        <el-form size="small" ref="settingsForm" label-width="260px" status-icon :model="settingsForm">
+            <el-form-item label="默认页面标题" prop="defaultTitle" :rules="{ required: true, message: '请输入默认页面标题' }">
+                <el-input v-model="settingsForm.defaultTitle" placeholder="请输入默认页面标题"></el-input>
+                <div class="tips">当分享插件未获取到页面标题时将使用默认页面标题</div>
+            </el-form-item>
+            <el-form-item label="默认封面图片" prop="defaultImageUrl" :rules="{ required: true, message: '请输入图片地址或点击上方按钮上传' }">
+                <el-button-group>
+                    <el-button size="mini" type="info" icon="el-icon-upload2" plain v-on:click="btnLayerClick({title: '上传图片', name: 'formLayerImageUpload', attributeName: 'defaultImageUrl', no: 0})">
+                        上传
+                    </el-button>
+                    <el-button size="mini" type="info" icon="el-icon-folder-opened" plain v-on:click="btnLayerClick({title: '选择图片素材', name: 'materialLayerImageSelect', attributeName: 'defaultImageUrl', no: 0, full: true})">
+                        选择
+                    </el-button>
+                    <el-button size="mini" type="info" icon="el-icon-view" plain :disabled="settingsForm.defaultImageUrl ? false : true" v-on:click="btnPreviewClick('defaultImageUrl', 0)">
+                        预览
+                    </el-button>
+                </el-button-group>
+                <el-input v-model="settingsForm.defaultImageUrl"
+                          placeholder="请输入图片地址或点击上方按钮上传">
+                </el-input>
+                <div class="tips">当分享插件未获取到封面图片时将使用默认封面图片</div>
+            </el-form-item>
+            <el-form-item label="默认页面介绍" prop="defaultDescription" :rules="{ required: true, message: '请输入默认页面介绍' }">
+                <el-input v-model="settingsForm.defaultDescription" type="textarea" :rows="5" placeholder="请输入默认页面介绍"></el-input>
+                <div class="tips">当分享插件未获取到页面介绍时将使用默认页面介绍</div>
+            </el-form-item>
+        </el-form>
 
-    <el-divider></el-divider>
-    <div style="height: 10px"></div>
+        <el-divider></el-divider>
+        <div style="height: 10px"></div>
 
-    <el-row>
-      <el-col :span="24" align="center">
-        <el-button type="primary" v-on:click="btnSettingsSubmitClick" size="small">保 存</el-button>
-      </el-col>
-    </el-row>
-  </el-tab-pane>
-  <el-tab-pane label="微信分享设置">
+        <el-row>
+            <el-col :span="24" align="center">
+                <el-button type="primary" v-on:click="btnSettingsSubmitClick" size="small">保 存</el-button>
+            </el-col>
+        </el-row>
+    </el-tab-pane>
+    <el-tab-pane label="微信分享设置">
 
-    <el-alert v-if="mpResult && mpResult.success" type="success" title="微信公众号设置保存成功！"></el-alert>
-    <el-alert v-else-if="mpResult && !mpResult.success" type="error" :title="mpResult.errorMessage" ></el-alert>
+        <el-alert v-if="mpResult && mpResult.success" type="success" title="微信公众号设置保存成功！"></el-alert>
+        <el-alert v-else-if="mpResult && !mpResult.success" type="error" :title="mpResult.errorMessage"></el-alert>
 
-    <div style="height: 10px"></div>
+        <div style="height: 10px"></div>
 
-    <el-form size="small" ref="wxShareForm" label-width="260px" status-icon :model="wxShareForm">
-      <el-form-item label="是否启用微信分享">
-        <el-radio v-model="wxShareForm.isWxShare" :label="true">启用</el-radio>
-        <el-radio v-model="wxShareForm.isWxShare" :label="false">不启用</el-radio>
-        <div class="tips">启用微信分享后，微信转发或分享时将显示完整的标题、封面及介绍</div>
-      </el-form-item>
-      <el-form-item v-if="wxShareForm.isWxShare" label="AppId" prop="mpAppId" :rules="{ required: true, message: '请输入AppId' }">
-        <el-input v-model="wxShareForm.mpAppId" placeholder="请输入AppId"></el-input>
-        <div class="tips">请进入微信公众平台，获取AppId</div>
-      </el-form-item>
-      <el-form-item v-if="wxShareForm.isWxShare" label="AppSecret" prop="mpAppSecret" :rules="{ required: true, message: '请输入AppSecret' }">
-        <el-input v-model="wxShareForm.mpAppSecret" placeholder="请输入AppSecret"></el-input>
-        <div class="tips">请进入微信公众平台，获取AppSecret</div>
-      </el-form-item>
-    </el-form>
+        <el-form size="small" ref="wxShareForm" label-width="260px" status-icon :model="wxShareForm">
+            <el-form-item label="是否启用微信分享">
+                <el-radio-group v-model="wxShareForm.isWxShare">
+                    <el-radio :label="true">启用</el-radio>
+                    <el-radio :label="false">不启用</el-radio>
+                </el-radio-group>
+                <div class="tips">启用微信分享后，微信转发或分享时将显示完整的标题、封面及介绍</div>
+            </el-form-item>
+            <el-form-item v-if="wxShareForm.isWxShare" label="AppId" prop="mpAppId" :rules="{ required: true, message: '请输入AppId' }">
+                <el-input v-model="wxShareForm.mpAppId" placeholder="请输入AppId"></el-input>
+                <div class="tips">请进入微信公众平台，获取AppId</div>
+            </el-form-item>
+            <el-form-item v-if="wxShareForm.isWxShare" label="AppSecret" prop="mpAppSecret" :rules="{ required: true, message: '请输入AppSecret' }">
+                <el-input v-model="wxShareForm.mpAppSecret" placeholder="请输入AppSecret"></el-input>
+                <div class="tips">请进入微信公众平台，获取AppSecret</div>
+            </el-form-item>
+        </el-form>
 
-    <template v-if="wxShareForm.isWxShare">
-      <div style="height: 10px"></div>
-      <el-alert type="info">
-        请进入微信公众平台，进入<strong>开发 -> 基本配置 -> IP白名单</strong>，将以下信息填入并启用。
-      </el-alert>
-      <div style="height: 10px"></div>
+        <template v-if="wxShareForm.isWxShare">
+            <div style="height: 10px"></div>
+            <el-alert type="info">
+                请进入微信公众平台，进入<strong>开发 -> 基本配置 -> IP白名单</strong>，将以下信息填入并启用。
+            </el-alert>
+            <div style="height: 10px"></div>
 
-      <el-form size="small" label-width="260px" status-icon>
-        <el-form-item label="IP白名单">
-          {{ ipAddress }}
-        </el-form-item>
-      </el-form>
-    </template>
+            <el-form size="small" label-width="260px" status-icon>
+                <el-form-item label="IP白名单">
+                    {{ ipAddress }}
+                </el-form-item>
+            </el-form>
+        </template>
 
-    <el-divider></el-divider>
-    <div style="height: 10px"></div>
+        <el-divider></el-divider>
+        <div style="height: 10px"></div>
 
-    <el-row>
-      <el-col :span="24" align="center">
-        <el-button type="primary" v-on:click="btnWxShareSubmitClick" size="small">保 存</el-button>
-      </el-col>
-    </el-row>
-  </el-tab-pane>
+        <el-row>
+            <el-col :span="24" align="center">
+                <el-button type="primary" v-on:click="btnWxShareSubmitClick" size="small">保 存</el-button>
+            </el-col>
+        </el-row>
+    </el-tab-pane>
 </el-tabs>
 
 @section Scripts{
-  <script src="/assets/share/index.js" type="text/javascript"></script>
+<script src="/assets/share/index.js" type="text/javascript"></script>
 }

--- a/wwwroot/assets/share/index.js
+++ b/wwwroot/assets/share/index.js
@@ -3,163 +3,164 @@ var $urlWxShare = '/share/wxShare';
 var $urlSettings = '/share/settings';
 
 var data = utils.init({
-  siteId: utils.getQueryInt('siteId'),
-  siteUrl: null,
-  ipAddress: null,
-  settingsForm: null,
-  wxShareForm: null,
-  mpResult: null
+    siteId: utils.getQueryInt('siteId'),
+    siteUrl: null,
+    ipAddress: null,
+    settingsForm: null,
+    wxShareForm: null,
+    mpResult: null
 });
 
 var methods = {
-  runFormLayerImageUploadText: function(attributeName, no, text) {
-    this.insertText(attributeName, no, text);
-  },
+    runFormLayerImageUploadText: function (attributeName, no, text) {
+        this.insertText(attributeName, no, text);
+    },
 
-  runMaterialLayerImageSelect: function(attributeName, no, text) {
-    this.insertText(attributeName, no, text);
-  },
+    runMaterialLayerImageSelect: function (attributeName, no, text) {
+        this.insertText(attributeName, no, text);
+    },
 
-  insertText: function(attributeName, no, text) {
-    this.settingsForm[attributeName] = text;
-    this.settingsForm = _.assign({}, this.settingsForm);
-  },
+    insertText: function (attributeName, no, text) {
+        this.settingsForm[attributeName] = text;
+        this.settingsForm = _.assign({}, this.settingsForm);
+    },
 
-  apiGet: function () {
-    var $this = this;
+    apiGet: function () {
+        var $this = this;
 
-    utils.loading(this, true);
-    $api.get($url, {
-      params: {
-        siteId: this.siteId
-      }
-    }).then(function (response) {
-      var res = response.data;
-      
-      $this.siteUrl = res.siteUrl;
-      $this.ipAddress = res.ipAddress;
-      $this.settingsForm = Object.assign({}, res.settings);
-      $this.wxShareForm = Object.assign({}, res.settings);
-    }).catch(function (error) {
-      utils.error(error);
-    }).then(function () {
-      utils.loading($this, false);
-    });
-  },
+        utils.loading(this, true);
+        $api.get($url, {
+            params: {
+                siteId: this.siteId
+            }
+        }).then(function (response) {
+            var res = response.data;
 
-  apiWxShareSubmit: function () {
-    this.mpResult = null;
-    var $this = this;
+            $this.siteUrl = res.siteUrl;
+            $this.ipAddress = res.ipAddress;
+            $this.settingsForm = Object.assign({}, res.settings);
+            $this.wxShareForm = Object.assign({}, res.settings);
+        }).catch(function (error) {
+            utils.error(error);
+        }).then(function () {
+            utils.loading($this, false);
+        });
+    },
 
-    utils.loading(this, true);
-    $api.post($urlWxShare, {
-      siteId: this.siteId,
-      mpAppId: this.wxShareForm.mpAppId,
-      mpAppSecret: this.wxShareForm.mpAppSecret
-    }).then(function (response) {
-      var res = response.data;
+    apiWxShareSubmit: function () {
+        this.mpResult = null;
+        var $this = this;
 
-      $this.mpResult = {
-        success: res.success,
-        errorMessage: res.errorMessage
-      };
-    }).catch(function (error) {
-      utils.error(error);
-    }).then(function () {
-      utils.loading($this, false);
-    });
-  },
+        utils.loading(this, true);
+        $api.post($urlWxShare, {
+            siteId: this.siteId,
+            mpAppId: this.wxShareForm.mpAppId,
+            mpAppSecret: this.wxShareForm.mpAppSecret,
+            isWxShare: this.wxShareForm.isWxShare
+        }).then(function (response) {
+            var res = response.data;
 
-  apiSettingsSubmit: function () {
-    var $this = this;
+            $this.mpResult = {
+                success: res.success,
+                errorMessage: res.errorMessage
+            };
+        }).catch(function (error) {
+            utils.error(error);
+        }).then(function () {
+            utils.loading($this, false);
+        });
+    },
 
-    utils.loading(this, true);
-    $api.post($urlSettings, {
-      siteId: this.siteId,
-      defaultTitle: this.settingsForm.defaultTitle,
-      defaultImageUrl: this.settingsForm.defaultImageUrl,
-      defaultDescription: this.settingsForm.defaultDescription
-    }).then(function (response) {
-      var res = response.data;
+    apiSettingsSubmit: function () {
+        var $this = this;
 
-      utils.success('页面分享设置保存成功！');
-    }).catch(function (error) {
-      utils.error(error);
-    }).then(function () {
-      utils.loading($this, false);
-    });
-  },
+        utils.loading(this, true);
+        $api.post($urlSettings, {
+            siteId: this.siteId,
+            defaultTitle: this.settingsForm.defaultTitle,
+            defaultImageUrl: this.settingsForm.defaultImageUrl,
+            defaultDescription: this.settingsForm.defaultDescription
+        }).then(function (response) {
+            var res = response.data;
 
-  btnSettingsSubmitClick: function () {
-    var $this = this;
+            utils.success('页面分享设置保存成功！');
+        }).catch(function (error) {
+            utils.error(error);
+        }).then(function () {
+            utils.loading($this, false);
+        });
+    },
 
-    this.$refs.settingsForm.validate(function(valid) {
-      if (valid) {
-        $this.apiSettingsSubmit();
-      }
-    });
-  },
+    btnSettingsSubmitClick: function () {
+        var $this = this;
 
-  btnWxShareSubmitClick: function () {
-    var $this = this;
+        this.$refs.settingsForm.validate(function (valid) {
+            if (valid) {
+                $this.apiSettingsSubmit();
+            }
+        });
+    },
 
-    this.$refs.wxShareForm.validate(function(valid) {
-      if (valid) {
-        $this.apiWxShareSubmit();
-      }
-    });
-  },
+    btnWxShareSubmitClick: function () {
+        var $this = this;
 
-  btnLayerClick: function(options) {
-    var query = {
-      siteId: this.siteId,
-      channelId: this.channelId
-    };
+        this.$refs.wxShareForm.validate(function (valid) {
+            if (valid) {
+                $this.apiWxShareSubmit();
+            }
+        });
+    },
 
-    if (options.contentId) {
-      query.contentId = options.contentId;
+    btnLayerClick: function (options) {
+        var query = {
+            siteId: this.siteId,
+            channelId: this.channelId
+        };
+
+        if (options.contentId) {
+            query.contentId = options.contentId;
+        }
+        if (options.attributeName) {
+            query.attributeName = options.attributeName;
+        }
+        if (options.no) {
+            query.no = options.no;
+        }
+
+        var args = {
+            title: options.title,
+            url: utils.getCommonUrl(options.name, query)
+        };
+        if (!options.full) {
+            args.width = options.width ? options.width : 700;
+            args.height = options.height ? options.height : 500;
+        }
+
+        utils.openLayer(args);
+    },
+
+    btnPreviewClick: function (attributeName, no) {
+        var data = [];
+        var imageUrl = this.settingsForm.defaultImageUrl;
+        imageUrl = utils.getUrl(this.siteUrl, imageUrl);
+        data.push({
+            "src": imageUrl
+        });
+        layer.photos({
+            photos: {
+                "start": no,
+                "data": data
+            }
+            , anim: 5
+        });
     }
-    if (options.attributeName) {
-      query.attributeName = options.attributeName;
-    }
-    if (options.no) {
-      query.no = options.no;
-    }
-
-    var args = {
-      title: options.title,
-      url: utils.getCommonUrl(options.name, query)
-    };
-    if (!options.full) {
-      args.width = options.width ? options.width : 700;
-      args.height = options.height ? options.height : 500;
-    }
-
-    utils.openLayer(args);
-  },
-
-  btnPreviewClick: function(attributeName, no) {
-    var data = [];
-    var imageUrl = this.settingsForm.defaultImageUrl;
-    imageUrl = utils.getUrl(this.siteUrl, imageUrl);
-    data.push({
-      "src": imageUrl
-    });
-    layer.photos({
-      photos: {
-        "start": no,
-        "data": data
-      }
-      ,anim: 5
-    });
-  }
 };
 
 var $vue = new Vue({
-  el: '#main',
-  data: data,
-  methods: methods,
-  created: function () {
-    this.apiGet();
-  }
+    el: '#main',
+    data: data,
+    methods: methods,
+    created: function () {
+        this.apiGet();
+    }
 });


### PR DESCRIPTION
- Buttons do not need to be displayed when WeChat share is off.
- Add modification and persistence to `isWxShare`
We save `isWxShare`, but the change `isWxShare` was not persisted, so `isWxShare` was always `false `.